### PR TITLE
Don't return err before empty buf init'ed

### DIFF
--- a/gobby.go
+++ b/gobby.go
@@ -57,7 +57,6 @@ func (gobby *Gobby) Load() error {
 
 	if err != nil {
 		log.Println("gobby file read error:", err)
-		return err
 	}
 
 	_, err = buf.Write(dat)


### PR DESCRIPTION
In order to not stick when reading before file created
